### PR TITLE
Update ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:19.10
 LABEL maintainer="Niklas Hauser <niklas.hauser@rwth-aachen.de>"
 LABEL Description="Image for building and debugging arm-embedded projects from git"
 WORKDIR /work


### PR DESCRIPTION
Ubuntu 18.10 (Cosmic) is end-of-life and the apt repositories have disappeared. This makes it impossible to (re)build this docker image or a image dependent on it.
```
E: The repository 'http://archive.ubuntu.com/ubuntu cosmic Release' no longer has a Release file.
```